### PR TITLE
Adds Accept Mission Outcome as new Conditional Hook (#1893)

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -43,6 +43,7 @@
 #include "pilotfile/pilotfile.h"
 #include "playerman/player.h"
 #include "popup/popup.h"
+#include "scripting/scripting.h"
 #include "ship/ship.h"
 #include "starfield/supernova.h"
 #include "ui/ui.h"
@@ -1201,6 +1202,9 @@ void mission_campaign_mission_over(bool do_next_mission)
 			Pilot.save_savefile();
 		}
 
+		// runs the new scripting conditional hook, "On Campaign Mission Accept" --wookieejedi
+		Script_system.RunCondition(CHA_CMISSIONACCEPT);
+		
 	} else {
 		// free up the goals and events which were just malloced.  It's kind of like erasing any fact
 		// that the player played this mission in the campaign.
@@ -1225,7 +1229,7 @@ void mission_campaign_mission_over(bool do_next_mission)
 
 		Sexp_nodes[mission_obj->formula].value = SEXP_UNKNOWN;
 	}
-
+	
 	if (do_next_mission)
 		mission_campaign_next_mission();			// sets up whatever needs to be set to actually play next mission
 }

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -85,6 +85,7 @@ flag_def_list Script_actions[] =
 	{ "On Beam Fire",			CHA_BEAMFIRE,		0 },
 	{ "On Simulation",			CHA_SIMULATION,		0 },
 	{ "On Load Screen",			CHA_LOADSCREEN,		0 },
+	{ "On Campaign Mission Accept", 	CHA_CMISSIONACCEPT,	0 },
 };
 
 int Num_script_actions = sizeof(Script_actions)/sizeof(flag_def_list);

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -100,6 +100,7 @@ extern bool script_hook_valid(script_hook *hook);
 #define CHA_BEAMFIRE        38
 #define CHA_SIMULATION      39
 #define CHA_LOADSCREEN      40
+#define CHA_CMISSIONACCEPT  41
 
 // management stuff
 void scripting_state_init();


### PR DESCRIPTION
* Adds Accept Mission Outcome Event to Game Events

Adds Accept Mission Outcome Event to Game Events, so scritps and other things can be called only when a campaign mission is accepted.

* Fixed double entry

* Define CHA_CMISSIONACCEPT

Adds line to define new conditional hook, CHA_CMISSIONACCEPT

* Add flag_def_list for On Campaign Mission Accept

Adds the proper flag_def_list for "On Campaign Mission Accept" CHA_CMISSIONACCEPT

* Runs New Conditional Hook

Runs the new conditional hook for "On Campaign Mission Accept"

* Reverts event changes

* Reverts state changese

* Reverts post_event change